### PR TITLE
Refactor CommandesAPI to return response and add error handling

### DIFF
--- a/lib/Api/CommandesApi.php
+++ b/lib/Api/CommandesApi.php
@@ -967,7 +967,8 @@ class CommandesApi
      */
     public function organizationsOrganizationSlugFormsFormTypeFormSlugItemsGet($organization_slug, $form_slug, $form_type, $from = null, $to = null, $user_search_key = null, $page_index = 1, $page_size = 20, $continuation_token = null, $tier_types = null, $item_states = null, $tier_name = null, $with_details = false, $sort_order = null, $sort_field = null, string $contentType = self::contentTypes['organizationsOrganizationSlugFormsFormTypeFormSlugItemsGet'][0])
     {
-        $this->organizationsOrganizationSlugFormsFormTypeFormSlugItemsGetWithHttpInfo($organization_slug, $form_slug, $form_type, $from, $to, $user_search_key, $page_index, $page_size, $continuation_token, $tier_types, $item_states, $tier_name, $with_details, $sort_order, $sort_field, $contentType);
+        list($response) = $this->organizationsOrganizationSlugFormsFormTypeFormSlugItemsGetWithHttpInfo($organization_slug, $form_slug, $form_type, $from, $to, $user_search_key, $page_index, $page_size, $continuation_token, $tier_types, $item_states, $tier_name, $with_details, $sort_order, $sort_field, $contentType);
+        return $response;
     }
 
     /**
@@ -1022,10 +1023,43 @@ class CommandesApi
 
             $statusCode = $response->getStatusCode();
 
+            switch($statusCode) {
+                case 200:
+                    return $this->handleResponseWithDataType(
+                        '\OpenAPI\Client\Model\HelloAssoApiV5CommonModelsCommonResultsWithPaginationModelOrder',
+                        $request,
+                        $response,
+                    );
+            }
 
-            return [null, $statusCode, $response->getHeaders()];
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            return $this->handleResponseWithDataType(
+                '\OpenAPI\Client\Model\HelloAssoApiV5CommonModelsCommonResultsWithPaginationModelOrder',
+                $request,
+                $response,
+            );
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\OpenAPI\Client\Model\HelloAssoApiV5CommonModelsCommonResultsWithPaginationModelOrder',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    throw $e;
             }
         
 

--- a/lib/Api/CommandesApi.php
+++ b/lib/Api/CommandesApi.php
@@ -961,7 +961,7 @@ class CommandesApi
      * @param  \OpenAPI\Client\Model\HelloAssoApiV5CommonModelsEnumsSortField|null $sort_field Sort forms items by a specific field (Date or UpdateDate). Default is date (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['organizationsOrganizationSlugFormsFormTypeFormSlugItemsGet'] to see the possible values for this operation
      *
-     * @return array of \OpenAPI\Client\Model\HelloAssoApiV5CommonModelsCommonResultsWithPaginationModelOrder, HTTP status code, HTTP response headers (array of strings)
+     * @return \OpenAPI\Client\Model\HelloAssoApiV5CommonModelsCommonResultsWithPaginationModelOrder
      * @throws \OpenAPI\Client\ApiException on non-2xx response or if the response body is not in the expected format
      * @throws \InvalidArgumentException     
      */

--- a/lib/Api/CommandesApi.php
+++ b/lib/Api/CommandesApi.php
@@ -961,9 +961,9 @@ class CommandesApi
      * @param  \OpenAPI\Client\Model\HelloAssoApiV5CommonModelsEnumsSortField|null $sort_field Sort forms items by a specific field (Date or UpdateDate). Default is date (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['organizationsOrganizationSlugFormsFormTypeFormSlugItemsGet'] to see the possible values for this operation
      *
+     * @return array of \OpenAPI\Client\Model\HelloAssoApiV5CommonModelsCommonResultsWithPaginationModelOrder, HTTP status code, HTTP response headers (array of strings)
      * @throws \OpenAPI\Client\ApiException on non-2xx response or if the response body is not in the expected format
-     * @throws \InvalidArgumentException
-     * @return void
+     * @throws \InvalidArgumentException     
      */
     public function organizationsOrganizationSlugFormsFormTypeFormSlugItemsGet($organization_slug, $form_slug, $form_type, $from = null, $to = null, $user_search_key = null, $page_index = 1, $page_size = 20, $continuation_token = null, $tier_types = null, $item_states = null, $tier_name = null, $with_details = false, $sort_order = null, $sort_field = null, string $contentType = self::contentTypes['organizationsOrganizationSlugFormsFormTypeFormSlugItemsGet'][0])
     {


### PR DESCRIPTION
Took inspiration from PaiementsAPI to complete what was missing here. See #1 

There's still an issue with `with_details` param which is set to boolean and then serialized as an int from the following code:
```
        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
            $with_details,
            'withDetails', // param base name
            'boolean', // openApiType
            'form', // style
            true, // explode
            false // required
        ) ?? []);
```

The API returns the following error
```
{"errors":{"withDetails":["The value '1' is not valid."]}
```

Workaround is to force "true" or "false" as string in organizationsOrganizationSlugFormsFormTypeFormSlugItemsGet